### PR TITLE
Solution for longest palindrome optimized

### DIFF
--- a/easy/409-longest-palindrome.ts
+++ b/easy/409-longest-palindrome.ts
@@ -38,3 +38,38 @@ function longestPalindrome(s: string): number {
 
 // runtime 30th percentile
 // memory 8th percentile
+
+function longestPalindromeOptimized(s: string): number {
+    if (s.length === 1) return 1;
+    if (s.length === 2) {
+        let sFlip = s.split('').reverse().join('');
+        if (s === sFlip) return 2;
+        return 1;
+    }
+
+    let map: Map<string,number> = new Map();
+
+    for (let i = 0; i < s.length; i++) {
+        if (map.has(s[i])) {
+            map.set(s[i], (map.get(s[i]) as number + 1))
+        } else {
+            map.set(s[i], 1);
+        }
+    }
+
+    let total = 0;
+    let odd = 0;
+    map.forEach((value) => {
+        if (value % 2 === 0) {
+            total += value;
+        } else if (value %2 !== 0) {
+            odd = 1;
+            total += (value - 1);
+        }
+    })
+
+    return (total + odd);
+};
+
+// runtime 91st percentile
+// memory 28th percentile


### PR DESCRIPTION
My solution for longest palindrome, optimized. Leveraging a [`map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) removes the need for a `set` and a `hash table`. That resulted in a >3x improvement in runtime and memory.