### PR TITLE
Fix ts issues with Counter II

### DIFF
--- a/easy/2665-counter-ii.ts
+++ b/easy/2665-counter-ii.ts
@@ -42,7 +42,7 @@ type Counter = {
     reset: () => number,
 }
 
-function createCounter(init: number): Counter {
+function createCounterII(init: number): Counter {
   let count = init;
 
   return {
@@ -59,7 +59,7 @@ function createCounter(init: number): Counter {
   };
 };
 
-let counter = createCounter(7);
+let counter = createCounterII(7);
 console.log(counter.increment()); // 8
 console.log(counter.decrement()); // 7
 console.log(counter.increment()); // 8


### PR DESCRIPTION
Counter I and Counter II have the same function name. This PR fixes that by renaming `createCounter` in Counter II to `createCounterII`. Also updates it in the invocation.